### PR TITLE
Use DrugBank CSV

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -9,9 +9,10 @@
     },
     "dumper": {
         "data_url": [
-            "http://localhost:8080/dataupload/mysrc/full.csv"
+            "http://localhost:8080/dataupload/mysrc/full.csv",
+            "https://go.drugbank.com/releases/5-1-9/downloads/all-drugbank-vocabulary"
         ],
-        "uncompress": false,
+        "uncompress": true,
         "release": "version:get_release"
     },
     "uploader": {


### PR DESCRIPTION
Uses [Drugbank Vocabulary](https://go.drugbank.com/releases/latest#open-data) CSV from DrugBank that is open source, instead of mychem for resolving DrugBank names, as mychem has stopped providing drugbank data. 

Note: I have changed the requirement for drugbank_id to drug_name to be injective instead of one-to-one, because according to the CSV there can be multiple IDs (Drugbank ID & Accession Numbers) for one name.